### PR TITLE
Add new cases and fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,30 @@
 import anycase
 
 camel("any case")   # "anyCase"
+cobol("any case")   # "ANY-CASE"
+dot("any case")   # "any.case"
 kebab("any case")   # "any-case"
 pascal("any case")  # "AnyCase"
+pascalSnake("any case")  # "Any_Case"
 path("any case")    # "any/case"
+screamingSnake("any case")  # "ANY_CASE"
 snake("any case")   # "any_case"
+train("any case")   # "Any-Case"
 plain("any-case")   # "any case"
 ```
 
 ## Supported cases
 
 - `camel`
+- `cobol`
+- `dot`
 - `kebab`
+- `pascal snake`
 - `pascal`
 - `path`
+- `screaming snake`
 - `snake`
+- `train`
 - `plain`
 
 If you don't see any case – feel free to open issue or pull request.

--- a/anycase.nimble
+++ b/anycase.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.2.0"
 author        = "lamartire"
 description   = "Convert strings to any case"
 license       = "MIT"

--- a/src/anycase.nim
+++ b/src/anycase.nim
@@ -1,13 +1,23 @@
 import anycase/camel
-import anycase/pascal
-import anycase/snake
+import anycase/cobol
+import anycase/dot
 import anycase/kebab
+import anycase/pascal
+import anycase/pascal_snake
 import anycase/path
 import anycase/plain
+import anycase/screaming_snake
+import anycase/snake
+import anycase/train
 
 export camel
-export pascal
-export snake
+export cobol
+export dot
 export kebab
+export pascal
+export pascalSnake
 export path
 export plain
+export screamingSnake
+export snake
+export train

--- a/src/anycase/cobol.nim
+++ b/src/anycase/cobol.nim
@@ -1,0 +1,7 @@
+import anycase/words
+from strutils import join, toUpperAscii
+
+proc cobol*(str: string): string =
+  let parts = words(str)
+
+  return join(parts, "-").toUpperAscii

--- a/src/anycase/dot.nim
+++ b/src/anycase/dot.nim
@@ -1,0 +1,7 @@
+import anycase/words
+from strutils import join
+
+proc dot*(str: string): string =
+  let parts = words(str)
+
+  return join(parts, ".")

--- a/src/anycase/pascal_snake.nim
+++ b/src/anycase/pascal_snake.nim
@@ -1,0 +1,8 @@
+import anycase/words
+from strutils import join, capitalizeAscii
+from sequtils import map
+
+proc pascalSnake*(str: string): string =
+  let parts = words(str)
+
+  return join(map(parts, capitalizeAscii), "_")

--- a/src/anycase/screaming_snake.nim
+++ b/src/anycase/screaming_snake.nim
@@ -1,0 +1,7 @@
+import anycase/words
+from strutils import join, toUpperAscii
+
+proc screamingSnake*(str: string): string =
+  let parts = words(str)
+
+  return join(parts, "_").toUpperAscii

--- a/src/anycase/train.nim
+++ b/src/anycase/train.nim
@@ -1,0 +1,8 @@
+import anycase/words
+from strutils import join, capitalizeAscii
+from sequtils import map
+
+proc train*(str: string): string =
+  let parts = words(str)
+
+  return join(map(parts, capitalizeAscii), "-")

--- a/src/anycase/words.nim
+++ b/src/anycase/words.nim
@@ -8,9 +8,9 @@ proc splitByUpperChars*(str: string): seq[string] =
   return map(parts, toLowerAscii)
 
 proc words*(str: string): seq[string] =
-  let parts = split(str, re"(-|_|/|\s)")
+  let parts = split(str, re"(-|_|/|\.|\s)")
 
   if parts.len == 1:
     return splitByUpperChars(str)
 
-  return parts
+  return map(parts, toLowerAscii)

--- a/tests/test_camel.nim
+++ b/tests/test_camel.nim
@@ -20,5 +20,20 @@ suite "camel":
   test "snake -> camel":
     check camel("change_my_case") == "changeMyCase"
 
+  test "pascalSnake -> camel":
+    check camel("Change_My_Case") == "changeMyCase"
+
+  test "screamingSnake -> camel":
+    check camel("CHANGE_MY_CASE") == "changeMyCase"
+
+  test "cobol -> camel":
+    check camel("CHANGE-MY-CASE") == "changeMyCase"
+
+  test "dot -> camel":
+    check camel("change.my.case") == "changeMyCase"
+
+  test "train -> camel":
+    check camel("Change-My-Case") == "changeMyCase"
+
   test "doesn't cut numbers":
     check camel("changeMyCase2") == "changeMyCase2"

--- a/tests/test_cobol.nim
+++ b/tests/test_cobol.nim
@@ -1,0 +1,39 @@
+import unittest
+import anycase/cobol
+
+suite "cobol":
+  test "plain -> cobol":
+    check cobol("change my case") == "CHANGE-MY-CASE"
+
+  test "path -> cobol":
+    check cobol("change/my/case") == "CHANGE-MY-CASE"
+
+  test "kebab -> cobol":
+    check cobol("change-my-case") == "CHANGE-MY-CASE"
+
+  test "camel -> cobol":
+    check cobol("changeMyCase") == "CHANGE-MY-CASE"
+
+  test "pascal -> cobol":
+    check cobol("ChangeMyCase") == "CHANGE-MY-CASE"
+
+  test "snake -> cobol":
+    check cobol("change_my_case") == "CHANGE-MY-CASE"
+
+  test "pascalSnake -> cobol":
+    check cobol("Change_My_Case") == "CHANGE-MY-CASE"
+
+  test "screamingSnake -> cobol":
+    check cobol("CHANGE_MY_CASE") == "CHANGE-MY-CASE"
+
+  test "cobol -> cobol":
+    check cobol("CHANGE-MY-CASE") == "CHANGE-MY-CASE"
+
+  test "dot -> cobol":
+    check cobol("change.my.case") == "CHANGE-MY-CASE"
+
+  test "train -> cobol":
+    check cobol("Change-My-Case") == "CHANGE-MY-CASE"
+
+  test "doesn't cut numbers":
+    check cobol("change_my_case_2") == "CHANGE-MY-CASE-2"

--- a/tests/test_dot.nim
+++ b/tests/test_dot.nim
@@ -1,0 +1,39 @@
+import unittest
+import anycase/dot
+
+suite "dot":
+  test "plain -> dot":
+    check dot("change my case") == "change.my.case"
+
+  test "path -> dot":
+    check dot("change/my/case") == "change.my.case"
+
+  test "kebab -> dot":
+    check dot("change-my-case") == "change.my.case"
+
+  test "camel -> dot":
+    check dot("changeMyCase") == "change.my.case"
+
+  test "pascal -> dot":
+    check dot("ChangeMyCase") == "change.my.case"
+
+  test "snake -> dot":
+    check dot("change_my_case") == "change.my.case"
+
+  test "pascalSnake -> dot":
+    check dot("Change_My_Case") == "change.my.case"
+
+  test "screamingSnake -> dot":
+    check dot("CHANGE_MY_CASE") == "change.my.case"
+
+  test "cobol -> dot":
+    check dot("CHANGE-MY-CASE") == "change.my.case"
+
+  test "dot -> dot":
+    check dot("change.my.case") == "change.my.case"
+
+  test "train -> dot":
+    check dot("Change-My-Case") == "change.my.case"
+
+  test "doesn't cut numbers":
+    check dot("change/my/case/2") == "change.my.case.2"

--- a/tests/test_kebab.nim
+++ b/tests/test_kebab.nim
@@ -20,5 +20,20 @@ suite "kebab":
   test "snake -> kebab":
     check kebab("change_my_case") == "change-my-case"
 
+  test "pascalSnake -> kebab":
+    check kebab("Change_My_Case") == "change-my-case"
+
+  test "screamingSnake -> kebab":
+    check kebab("CHANGE_MY_CASE") == "change-my-case"
+
+  test "cobol -> kebab":
+    check kebab("CHANGE-MY-CASE") == "change-my-case"
+
+  test "dot -> kebab":
+    check kebab("change.my.case") == "change-my-case"
+
+  test "train -> kebab":
+    check kebab("Change-My-Case") == "change-my-case"
+
   test "doesn't cut numbers":
     check kebab("change-my-case-2") == "change-my-case-2"

--- a/tests/test_pascal.nim
+++ b/tests/test_pascal.nim
@@ -20,5 +20,20 @@ suite "pascal":
   test "snake -> pascal":
     check pascal("change_my_case") == "ChangeMyCase"
 
+  test "pascalSnake -> pascal":
+    check pascal("Change_My_Case") == "ChangeMyCase"
+
+  test "screamingSnake -> pascal":
+    check pascal("CHANGE_MY_CASE") == "ChangeMyCase"
+
+  test "cobol -> pascal":
+    check pascal("CHANGE-MY-CASE") == "ChangeMyCase"
+
+  test "dot -> pascal":
+    check pascal("change.my.case") == "ChangeMyCase"
+
+  test "train -> pascal":
+    check pascal("Change-My-Case") == "ChangeMyCase"
+
   test "doesn't cut numbers":
     check pascal("ChangeMyCase2") == "ChangeMyCase2"

--- a/tests/test_pascal_snake.nim
+++ b/tests/test_pascal_snake.nim
@@ -1,0 +1,39 @@
+import unittest
+import anycase/pascal_snake
+
+suite "pascalSnake":
+  test "plain -> pascalSnake":
+    check pascalSnake("change my case") == "Change_My_Case"
+
+  test "path -> pascalSnake":
+    check pascalSnake("change/my/case") == "Change_My_Case"
+
+  test "kebab -> pascalSnake":
+    check pascalSnake("change-my-case") == "Change_My_Case"
+
+  test "camel -> pascalSnake":
+    check pascalSnake("changeMyCase") == "Change_My_Case"
+
+  test "pascal -> pascalSnake":
+    check pascalSnake("ChangeMyCase") == "Change_My_Case"
+
+  test "snake -> pascalSnake":
+    check pascalSnake("change_my_case") == "Change_My_Case"
+
+  test "pascalSnake -> pascalSnake":
+    check pascalSnake("Change_My_Case") == "Change_My_Case"
+
+  test "screamingSnake -> pascalSnake":
+    check pascalSnake("CHANGE_MY_CASE") == "Change_My_Case"
+
+  test "cobol -> pascalSnake":
+    check pascalSnake("CHANGE-MY-CASE") == "Change_My_Case"
+
+  test "dot -> pascalSnake":
+    check pascalSnake("change.my.case") == "Change_My_Case"
+
+  test "train -> pascalSnake":
+    check pascalSnake("Change-My-Case") == "Change_My_Case"
+
+  test "doesn't cut numbers":
+    check pascalSnake("change_my_case_2") == "Change_My_Case_2"

--- a/tests/test_path.nim
+++ b/tests/test_path.nim
@@ -20,5 +20,20 @@ suite "path":
   test "snake -> path":
     check path("change_my_case") == "change/my/case"
 
+  test "pascalSnake -> path":
+    check path("Change_My_Case") == "change/my/case"
+
+  test "screamingSnake -> path":
+    check path("CHANGE_MY_CASE") == "change/my/case"
+
+  test "cobol -> path":
+    check path("CHANGE-MY-CASE") == "change/my/case"
+
+  test "dot -> path":
+    check path("change.my.case") == "change/my/case"
+
+  test "train -> path":
+    check path("Change-My-Case") == "change/my/case"
+
   test "doesn't cut numbers":
     check path("change/my/case/2") == "change/my/case/2"

--- a/tests/test_plain.nim
+++ b/tests/test_plain.nim
@@ -20,5 +20,20 @@ suite "plain":
   test "snake -> plain":
     check plain("change_my_case") == "change my case"
 
+  test "pascalSnake -> plain":
+    check plain("Change_My_Case") == "change my case"
+
+  test "screamingSnake -> plain":
+    check plain("CHANGE_MY_CASE") == "change my case"
+
+  test "cobol -> plain":
+    check plain("CHANGE-MY-CASE") == "change my case"
+
+  test "dot -> plain":
+    check plain("change.my.case") == "change my case"
+
+  test "train -> plain":
+    check plain("Change-My-Case") == "change my case"
+
   test "doesn't cut numbers":
     check plain("change my case 2") == "change my case 2"

--- a/tests/test_screaming_snake.nim
+++ b/tests/test_screaming_snake.nim
@@ -1,0 +1,39 @@
+import unittest
+import anycase/screaming_snake
+
+suite "screamingSnake":
+  test "plain -> screamingSnake":
+    check screamingSnake("change my case") == "CHANGE_MY_CASE"
+
+  test "path -> screamingSnake":
+    check screamingSnake("change/my/case") == "CHANGE_MY_CASE"
+
+  test "kebab -> screamingSnake":
+    check screamingSnake("change-my-case") == "CHANGE_MY_CASE"
+
+  test "camel -> screamingSnake":
+    check screamingSnake("changeMyCase") == "CHANGE_MY_CASE"
+
+  test "pascal -> screamingSnake":
+    check screamingSnake("ChangeMyCase") == "CHANGE_MY_CASE"
+
+  test "snake -> screamingSnake":
+    check screamingSnake("change_my_case") == "CHANGE_MY_CASE"
+
+  test "pascalSnake -> screamingSnake":
+    check screamingSnake("Change_My_Case") == "CHANGE_MY_CASE"
+
+  test "screamingSnake -> screamingSnake":
+    check screamingSnake("CHANGE_MY_CASE") == "CHANGE_MY_CASE"
+
+  test "cobol -> screamingSnake":
+    check screamingSnake("CHANGE-MY-CASE") == "CHANGE_MY_CASE"
+
+  test "dot -> screamingSnake":
+    check screamingSnake("change.my.case") == "CHANGE_MY_CASE"
+
+  test "train -> screamingSnake":
+    check screamingSnake("Change-My-Case") == "CHANGE_MY_CASE"
+
+  test "doesn't cut numbers":
+    check screamingSnake("change_my_case_2") == "CHANGE_MY_CASE_2"

--- a/tests/test_snake.nim
+++ b/tests/test_snake.nim
@@ -20,5 +20,20 @@ suite "snake":
   test "snake -> snake":
     check snake("change_my_case") == "change_my_case"
 
+  test "pascalSnake -> snake":
+    check snake("Change_My_Case") == "change_my_case"
+
+  test "screamingSnake -> snake":
+    check snake("CHANGE_MY_CASE") == "change_my_case"
+
+  test "cobol -> snake":
+    check snake("CHANGE-MY-CASE") == "change_my_case"
+
+  test "dot -> snake":
+    check snake("change.my.case") == "change_my_case"
+
+  test "train -> snake":
+    check snake("Change-My-Case") == "change_my_case"
+
   test "doesn't cut numbers":
     check snake("change_my_case_2") == "change_my_case_2"

--- a/tests/test_train.nim
+++ b/tests/test_train.nim
@@ -1,0 +1,39 @@
+import unittest
+import anycase/train
+
+suite "train":
+  test "plain -> train":
+    check train("change my case") == "Change-My-Case"
+
+  test "path -> train":
+    check train("change/my/case") == "Change-My-Case"
+
+  test "kebab -> train":
+    check train("change-my-case") == "Change-My-Case"
+
+  test "camel -> train":
+    check train("changeMyCase") == "Change-My-Case"
+
+  test "pascal -> train":
+    check train("ChangeMyCase") == "Change-My-Case"
+
+  test "snake -> train":
+    check train("change_my_case") == "Change-My-Case"
+
+  test "pascalSnake -> train":
+    check train("Change_My_Case") == "Change-My-Case"
+
+  test "screamingSnake -> train":
+    check train("CHANGE_MY_CASE") == "Change-My-Case"
+
+  test "cobol -> train":
+    check train("CHANGE-MY-CASE") == "Change-My-Case"
+
+  test "dot -> train":
+    check train("change.my.case") == "Change-My-Case"
+
+  test "train -> train":
+    check train("Change-My-Case") == "Change-My-Case"
+
+  test "doesn't cut numbers":
+    check train("change_my_case_2") == "Change-My-Case-2"

--- a/tests/test_words.nim
+++ b/tests/test_words.nim
@@ -20,5 +20,20 @@ suite "words":
   test "snake -> words":
     check words("change_my_case") == @["change", "my", "case"]
 
+  test "pascalSnake -> words":
+    check words("Change_My_Case") == @["change", "my", "case"]
+
+  test "screamingSnake -> words":
+    check words("CHANGE_MY_CASE") == @["change", "my", "case"]
+
+  test "cobol -> words":
+    check words("CHANGE-MY-CASE") == @["change", "my", "case"]
+
+  test "dot -> words":
+    check words("change.my.case") == @["change", "my", "case"]
+
+  test "train -> words":
+    check words("Change-My-Case") == @["change", "my", "case"]
+
   test "doesn't cut numbers":
     check words("change my case 2") == @["change", "my", "case", "2"]


### PR DESCRIPTION
* Add COBOL-CASE
* Add dot.case
* Add Pascal_Snake_Case
* Add SCREAMING_SNAKE_CASE
* Add Train-Case
* Fix words method to convert to lower case even if the split was done by separators like underscore. This fixes a bug of converting train  to camel case. Before the fix doing `camel("Convert-My-Case")` produced `"ConvertMyCase"` instead of `"convertMyCase"`