### PR TITLE
Word tokenizer fixes

### DIFF
--- a/anycase.nimble
+++ b/anycase.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "lamartire"
 description   = "Convert strings to any case"
 license       = "MIT"

--- a/src/anycase/snake.nim
+++ b/src/anycase/snake.nim
@@ -1,5 +1,5 @@
 import anycase/words
-from strutils import join, capitalizeAscii
+from strutils import join
 
 proc snake*(str: string): string =
   let parts = words(str)

--- a/src/anycase/words.nim
+++ b/src/anycase/words.nim
@@ -1,16 +1,17 @@
 from re import split, re, findAll
-from strutils import count, toLowerAscii
-from sequtils import map
+from strutils import toLowerAscii
+from sequtils import map, filterIt
 
-proc splitByUpperChars*(str: string): seq[string] =
-  let parts = findAll(str, re"(^[a-z0-9][a-z0-9]+|[A-Z0-9][a-z0-9]+)")
+proc splitBySymbols(str: string): seq[string] =
+  return split(str, re"(-|_|\/|\.|\s)").filterIt(it != "")
 
-  return map(parts, toLowerAscii)
+proc splitByUpperChars(str: string): seq[string] =
+  return findAll(str, re"(^[a-z0-9]+|[A-Z0-9][a-z0-9]*)")
 
 proc words*(str: string): seq[string] =
-  let parts = split(str, re"(-|_|/|\.|\s)")
+  var parts = splitBySymbols(str)
 
   if parts.len == 1:
-    return splitByUpperChars(str)
+    parts = splitByUpperChars(str)
 
   return map(parts, toLowerAscii)

--- a/tests/test_camel.nim
+++ b/tests/test_camel.nim
@@ -37,3 +37,8 @@ suite "camel":
 
   test "doesn't cut numbers":
     check camel("changeMyCase2") == "changeMyCase2"
+
+  test "single character tokens":
+    check camel("c") == "c"
+    check camel("C") == "c"
+    check camel("CMC") == "cMC"

--- a/tests/test_cobol.nim
+++ b/tests/test_cobol.nim
@@ -37,3 +37,8 @@ suite "cobol":
 
   test "doesn't cut numbers":
     check cobol("change_my_case_2") == "CHANGE-MY-CASE-2"
+
+  test "single character tokens":
+    check cobol("c") == "C"
+    check cobol("C") == "C"
+    check cobol("CMC") == "C-M-C"

--- a/tests/test_dot.nim
+++ b/tests/test_dot.nim
@@ -37,3 +37,8 @@ suite "dot":
 
   test "doesn't cut numbers":
     check dot("change/my/case/2") == "change.my.case.2"
+
+  test "single character tokens":
+    check dot("c") == "c"
+    check dot("C") == "c"
+    check dot("CMC") == "c.m.c"

--- a/tests/test_kebab.nim
+++ b/tests/test_kebab.nim
@@ -37,3 +37,8 @@ suite "kebab":
 
   test "doesn't cut numbers":
     check kebab("change-my-case-2") == "change-my-case-2"
+
+  test "single character tokens":
+    check kebab("c") == "c"
+    check kebab("C") == "c"
+    check kebab("CMC") == "c-m-c"

--- a/tests/test_pascal.nim
+++ b/tests/test_pascal.nim
@@ -37,3 +37,8 @@ suite "pascal":
 
   test "doesn't cut numbers":
     check pascal("ChangeMyCase2") == "ChangeMyCase2"
+
+  test "single character tokens":
+    check pascal("c") == "C"
+    check pascal("C") == "C"
+    check pascal("CMC") == "CMC"

--- a/tests/test_pascal_snake.nim
+++ b/tests/test_pascal_snake.nim
@@ -37,3 +37,8 @@ suite "pascalSnake":
 
   test "doesn't cut numbers":
     check pascalSnake("change_my_case_2") == "Change_My_Case_2"
+
+  test "single character tokens":
+    check pascalSnake("c") == "C"
+    check pascalSnake("C") == "C"
+    check pascalSnake("CMC") == "C_M_C"

--- a/tests/test_path.nim
+++ b/tests/test_path.nim
@@ -37,3 +37,8 @@ suite "path":
 
   test "doesn't cut numbers":
     check path("change/my/case/2") == "change/my/case/2"
+
+  test "single character tokens":
+    check path("c") == "c"
+    check path("C") == "c"
+    check path("CMC") == "c/m/c"

--- a/tests/test_plain.nim
+++ b/tests/test_plain.nim
@@ -37,3 +37,8 @@ suite "plain":
 
   test "doesn't cut numbers":
     check plain("change my case 2") == "change my case 2"
+
+  test "single character tokens":
+    check plain("c") == "c"
+    check plain("C") == "c"
+    check plain("CMC") == "c m c"

--- a/tests/test_screaming_snake.nim
+++ b/tests/test_screaming_snake.nim
@@ -37,3 +37,8 @@ suite "screamingSnake":
 
   test "doesn't cut numbers":
     check screamingSnake("change_my_case_2") == "CHANGE_MY_CASE_2"
+
+  test "single character tokens":
+    check screamingSnake("c") == "C"
+    check screamingSnake("C") == "C"
+    check screamingSnake("CMC") == "C_M_C"

--- a/tests/test_snake.nim
+++ b/tests/test_snake.nim
@@ -37,3 +37,8 @@ suite "snake":
 
   test "doesn't cut numbers":
     check snake("change_my_case_2") == "change_my_case_2"
+
+  test "single character tokens":
+    check snake("c") == "c"
+    check snake("C") == "c"
+    check snake("CMC") == "c_m_c"

--- a/tests/test_train.nim
+++ b/tests/test_train.nim
@@ -37,3 +37,8 @@ suite "train":
 
   test "doesn't cut numbers":
     check train("change_my_case_2") == "Change-My-Case-2"
+
+  test "single character tokens":
+    check train("c") == "C"
+    check train("C") == "C"
+    check train("CMC") == "C-M-C"

--- a/tests/test_words.nim
+++ b/tests/test_words.nim
@@ -37,3 +37,28 @@ suite "words":
 
   test "doesn't cut numbers":
     check words("change my case 2") == @["change", "my", "case", "2"]
+    check words("2 change my case") == @["2", "change", "my", "case"]
+
+  test "skip empty tokens":
+    check words(" change   my  case  ") == @["change", "my", "case"]
+    check words("change.-my  _case") == @["change", "my", "case"]
+    check words("change..my--case") == @["change", "my", "case"]
+    check words("--change..my--case.") == @["change", "my", "case"]
+    check words("  ChangeMyCase---") == @["change", "my", "case"]
+
+  test "single character":
+    check words("c") == @["c"]
+    check words("C") == @["c"]
+
+  test "two letter strings":
+    check words("cm") == @["cm"]
+    check words("Cm") == @["cm"]
+    check words("cM") == @["c", "m"]
+    check words("CM") == @["c", "m"]
+
+  test "upper ending strings":
+    check words("CM") == @["c", "m"]
+    check words("ChangeM") == @["change", "m"]
+    check words("changeM") == @["change", "m"]
+    check words("changeMyC") == @["change", "my", "c"]
+    check words("changeMyCASE") == @["change", "my", "c", "a", "s", "e"]


### PR DESCRIPTION
* Fix `splitByUpperChars` method to handle single char tokens. https://github.com/epszaw/anycase/issues/3
* Add the support to discard all empty tokens by default
* Make private `splitByUpperChars` method
* Remove unused imports
* Jump to version 0.2.1